### PR TITLE
Fix config name, start date and log duration in Manual mode

### DIFF
--- a/wakatime-logger-Manual/wakatime_logger.py
+++ b/wakatime-logger-Manual/wakatime_logger.py
@@ -6,7 +6,7 @@ import os
 import configparser
 
 config = configparser.ConfigParser()
-config.read('my_config.ini')
+config.read('config.ini')
 
 FILE_NAME = config.get("Waka", "fileName")
 API_KEY = config.get("Waka", "apiKey")
@@ -65,9 +65,9 @@ def run_the_program():
     if not os.path.exists(FILE_NAME):
         print("It looks like this is the first time you run this script!")
         print("This is the start date: {0}".format(START_DATE))
-        start_date = datetime.strptime(START_DATE, "%Y-%m-%d").date()
+        start_date = START_DATE
         df = pd.DataFrame(columns=["date", "project", "duration"])
-        write_data_to_dataframe(df, start_date, date.today())
+        write_data_to_dataframe(df, start_date, date.today() + timedelta(days=1))
         df.to_csv(FILE_NAME)
     else:
         df = pd.DataFrame.from_csv(FILE_NAME, header=0)

--- a/wakatime-logger-Manual/wakatime_logger.py
+++ b/wakatime-logger-Manual/wakatime_logger.py
@@ -67,10 +67,10 @@ def run_the_program():
         print("This is the start date: {0}".format(START_DATE))
         start_date = START_DATE
         df = pd.DataFrame(columns=["date", "project", "duration"])
-        write_data_to_dataframe(df, start_date, date.today() + timedelta(days=1))
+        write_data_to_dataframe(df, start_date, date.today())
         df.to_csv(FILE_NAME)
     else:
-        df = pd.DataFrame.from_csv(FILE_NAME, header=0)
+        df = pd.read_csv(FILE_NAME)
         # Here we don't need start_date because it is calculated from previous entries
         write_data_to_dataframe(df, START_DATE, date.today())
         df.to_csv(FILE_NAME)

--- a/wakatime-logger-Manual/wakatime_logger.py
+++ b/wakatime-logger-Manual/wakatime_logger.py
@@ -1,9 +1,11 @@
-import requests
 import base64
-from datetime import timedelta, date, datetime
-import pandas as pd
-import os
 import configparser
+import os
+import sys
+from datetime import timedelta, date, datetime
+
+import pandas as pd
+import requests
 
 config = configparser.ConfigParser()
 config.read('config.ini')
@@ -20,8 +22,8 @@ def prepare_request_header(api_key_in_bytes):
     return headers
 
 
-def get_durations_from_waka(date, header):
-    req_url = BASE_URL + date.strftime("%Y-%m-%d")
+def get_durations_from_waka(waka_date, header):
+    req_url = BASE_URL + waka_date.strftime("%Y-%m-%d")
     response = requests.get(req_url, headers=header)
     return response.json()
 
@@ -61,7 +63,7 @@ def write_data_to_dataframe(df, start_date, end_date):
         print("Durations saved for: {0}".format(d.strftime("%Y-%m-%d")))
 
 
-def run_the_program():
+def main():
     if not os.path.exists(FILE_NAME):
         print("It looks like this is the first time you run this script!")
         print("This is the start date: {0}".format(START_DATE))
@@ -77,5 +79,6 @@ def run_the_program():
 
     print("Data collection stopped!")
 
-run_the_program()
 
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This should work as intended now, surprising that the API hasn't changed in 5 years lmao. thanks for making this script

Time spent on this patch: [![wakatime](https://wakatime.com/badge/user/fd57ff6b-f3f1-4957-b9c6-7e09bc3f0559/project/bde867dc-dd4c-4e3d-ace3-b15768f6270e.svg)](https://wakatime.com/badge/user/fd57ff6b-f3f1-4957-b9c6-7e09bc3f0559/project/bde867dc-dd4c-4e3d-ace3-b15768f6270e)